### PR TITLE
애플리케이션 서비스를 리팩토링한다.

### DIFF
--- a/src/main/kotlin/com/example/estdelivery/application/HandoutCouponService.kt
+++ b/src/main/kotlin/com/example/estdelivery/application/HandoutCouponService.kt
@@ -9,12 +9,18 @@ import com.example.estdelivery.application.port.out.UpdateShopOwnerStatePort
 import com.example.estdelivery.application.port.out.state.CouponState
 import com.example.estdelivery.application.port.out.state.ShopOwnerState
 import com.example.estdelivery.domain.coupon.Coupon
+import com.example.estdelivery.domain.shop.ShopOwner
 
 class HandoutCouponService(
-    private val loadShopOwnerStatePort: LoadShopOwnerStatePort,
-    private val loadCouponStatePort: LoadCouponStatePort,
-    private val updateShopOwnerStatePort: UpdateShopOwnerStatePort,
-    private val createCouponStatePort: CreateCouponStatePort,
+    loadShopOwnerStatePort: LoadShopOwnerStatePort,
+    loadCouponStatePort: LoadCouponStatePort,
+    updateShopOwnerStatePort: UpdateShopOwnerStatePort,
+    createCouponStatePort: CreateCouponStatePort,
+    private val getShopOwner: (HandoutCouponCommand) -> ShopOwner = { loadShopOwnerStatePort.findById(it.shopOwnerId).toShopOwner() },
+    private val notExistCoupon: (Long) -> Boolean = { loadCouponStatePort.exists(it).not() },
+    private val getCoupon: (Long) -> Coupon = { loadCouponStatePort.findById(it).toCoupon() },
+    private val updateShopOwner: (ShopOwner) -> Unit = { updateShopOwnerStatePort.update(ShopOwnerState.from(it)) },
+    private val createCoupon: (Coupon) -> Coupon = { createCouponStatePort.create(CouponState.from(it)).toCoupon() },
 ) : HandoutCouponUseCase {
     /**
      * 1. 가게 주인 정보를 조회한다.
@@ -24,20 +30,18 @@ class HandoutCouponService(
      * @param handoutCouponCommand 나눠줄 쿠폰 정보와 가게 주인 정보
      */
     override fun handoutCoupon(handoutCouponCommand: HandoutCouponCommand) {
-        val shopOwner = loadShopOwnerStatePort.findById(handoutCouponCommand.shopOwnerId).toShopOwner()
+        val shopOwner = getShopOwner(handoutCouponCommand)
         val handoutCoupon: Coupon = getHandoutCoupon(handoutCouponCommand)
         shopOwner.handOutCouponToRoyalCustomersInShop(handoutCoupon)
-        updateShopOwnerStatePort.update(ShopOwnerState.from(shopOwner))
+        updateShopOwner(shopOwner)
     }
 
     private fun getHandoutCoupon(handoutCouponCommand: HandoutCouponCommand): Coupon {
         val id = handoutCouponCommand.coupon.id
-        if (id == null || loadCouponStatePort.exists(id).not()) {
-            val handoutCoupon = createCouponStatePort.create(CouponState.from(handoutCouponCommand.coupon)).toCoupon()
-            return handoutCoupon
+        if (id == null || notExistCoupon(id)) {
+            return createCoupon(handoutCouponCommand.coupon)
         }
 
-        val handoutCoupon: Coupon = loadCouponStatePort.findById(id).toCoupon()
-        return handoutCoupon
+        return getCoupon(id)
     }
 }

--- a/src/main/kotlin/com/example/estdelivery/application/port/in/command/HandoutCouponCommand.kt
+++ b/src/main/kotlin/com/example/estdelivery/application/port/in/command/HandoutCouponCommand.kt
@@ -2,4 +2,8 @@ package com.example.estdelivery.application.port.`in`.command
 
 import com.example.estdelivery.domain.coupon.Coupon
 
-class HandoutCouponCommand(val shopOwnerId: Long, val shopId: Long, val coupon: Coupon)
+class HandoutCouponCommand(
+    val shopOwnerId: Long,
+    val shopId: Long,
+    val coupon: Coupon
+)


### PR DESCRIPTION
### Summary

애플리케이션 서비스에서 의존하는 port.out 레이어를 격리합니다.

### Description

애플리케이션 서비스에서 port.out 레이어 클래스를 격리해서 복잡도를 낮췄습니다. 또한 port를 외부에 노출하지 않게 해 결합력을 낮췄습니다. 이제 애플리케이션 서비스에서 저장되기 위해 객체 상태로 변환하게 되거나 조회하기 위해 식별자를 꺼내는 등의 행위를 이해할 필요가 없습니다.

### Result

코드 가독성이 개선됩니다.

ASIS

```kotlin
override fun publishCoupon(publishCouponCommand: PublishCouponCommand) {
    val shopOwner = loadShopOwnerPort.findById(publishCouponCommand.shopOwnerId).toShopOwner()
    val publishedCoupon = createCouponStatePort.create(CouponState.from(publishCouponCommand.coupon)).toCoupon()
    shopOwner.publishCouponInShop(publishedCoupon)
    updateShopOwnerStatePort.update(ShopOwnerState.from(shopOwner))
}
```

TOBE

```kotlin
override fun publishCoupon(publishCouponCommand: PublishCouponCommand) {
    val shopOwner = findShopOwner(publishCouponCommand)
    val publishedCoupon = createCoupon(publishCouponCommand)
    shopOwner.publishCouponInShop(publishedCoupon)
    updateShopOwner(shopOwner)
}
```
