### PR TITLE
자동으로 계약서(contract)가 작성되도록 수정한다.

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -5,7 +5,9 @@ plugins {
     id("io.spring.dependency-management") version "1.1.4"
     id("com.google.osdetector") version "1.7.1"
     kotlin("jvm") version "1.9.23"
+    kotlin("plugin.allopen") version "1.9.23"
     kotlin("plugin.spring") version "1.9.23"
+    kotlin("plugin.jpa") version "1.9.23"
 }
 
 allprojects {
@@ -20,6 +22,8 @@ subprojects {
         plugin("org.springframework.boot")
         plugin("org.jetbrains.kotlin.jvm")
         plugin("org.jetbrains.kotlin.plugin.spring")
+        plugin("org.jetbrains.kotlin.plugin.jpa")
+        plugin("org.jetbrains.kotlin.plugin.allopen")
         plugin("com.google.osdetector")
     }
 
@@ -65,5 +69,11 @@ subprojects {
 
     tasks.test {
         useJUnitPlatform()
+    }
+
+    allOpen {
+        annotation("jakarta.persistence.Entity")
+        annotation("jakarta.persistence.Embeddable")
+        annotation("jakarta.persistence.MappedSuperclass")
     }
 }

--- a/contract-stubs/META-INF/com.example.estdelivery.event/event/1.0-SNAPSHOT/contracts/event/findEvent.kts
+++ b/contract-stubs/META-INF/com.example.estdelivery.event/event/1.0-SNAPSHOT/contracts/event/findEvent.kts
@@ -1,0 +1,42 @@
+package event
+
+import org.springframework.cloud.contract.spec.ContractDsl.Companion.contract
+
+contract {
+    request {
+        method = GET
+        url = url("/events/1")
+    }
+    response {
+        status = OK
+        headers {
+            contentType = "application/json"
+        }
+        body = body(
+            "id" to 1,
+            "description" to "이벤트 설명",
+            "isProgress" to true,
+            "discountType" to "FIXED",
+            "intervalsProbability" to listOf(
+                mapOf(
+                    "min" to 1000,
+                    "max" to 1500,
+                    "probability" to 0.5
+                ),
+                mapOf(
+                    "min" to 1600,
+                    "max" to 2000,
+                    "probability" to 0.3
+                ),
+                mapOf(
+                    "min" to 2100,
+                    "max" to 2500,
+                    "probability" to 0.2
+                )
+            ),
+            "discountRangeMin" to 1000,
+            "discountRangeMax" to 2500,
+            "participatedMembers" to listOf(1, 2, 3)
+        )
+    }
+}

--- a/contract-stubs/META-INF/com.example.estdelivery.event/event/1.0-SNAPSHOT/contracts/event/participateMember.kts
+++ b/contract-stubs/META-INF/com.example.estdelivery.event/event/1.0-SNAPSHOT/contracts/event/participateMember.kts
@@ -1,0 +1,12 @@
+
+import org.springframework.cloud.contract.spec.ContractDsl.Companion.contract
+
+contract {
+    request {
+        method = PUT
+        url = url("/events/1/participants/1")
+    }
+    response {
+        status = OK
+    }
+}

--- a/contract-stubs/META-INF/com.example.estdelivery.member/member/1.0-SNAPSHOT/contracts/member/findMember.kts
+++ b/contract-stubs/META-INF/com.example.estdelivery.member/member/1.0-SNAPSHOT/contracts/member/findMember.kts
@@ -1,0 +1,20 @@
+package member
+
+import org.springframework.cloud.contract.spec.ContractDsl.Companion.contract
+
+contract {
+    request {
+        method = GET
+        url = url(v(consumer(regex("\\/members\\/[0-9]{1,10}")), producer("/members/1")))
+    }
+    response {
+        status = OK
+        headers {
+            contentType = "application/json"
+        }
+        body = body(
+            "id" to 1,
+            "name" to "이건창"
+        )
+    }
+}

--- a/contract-stubs/META-INF/com.example.estdelivery.shop/shop/1.0-SNAPSHOT/contracts/shop/findShopOwnerByShopId.kts
+++ b/contract-stubs/META-INF/com.example.estdelivery.shop/shop/1.0-SNAPSHOT/contracts/shop/findShopOwnerByShopId.kts
@@ -1,0 +1,42 @@
+package shop
+
+import org.springframework.cloud.contract.spec.ContractDsl.Companion.contract
+
+listOf(
+    contract {
+        name = "get owner shop id is 1"
+        request {
+            method = GET
+            url = url("/owners/shop/1")
+        }
+        response {
+            status = OK
+            headers {
+                contentType = "application/json"
+            }
+            body = body(
+                "shopOwnerId" to 1,
+                "shopId" to 1,
+                "shopName" to "첫 번째 가게"
+            )
+        }
+    },
+    contract {
+        name = "get owner shop id is 2"
+        request {
+            method = GET
+            url = url("/owners/shop/2")
+        }
+        response {
+            status = OK
+            headers {
+                contentType = "application/json"
+            }
+            body = body(
+                "shopOwnerId" to 2,
+                "shopId" to 2,
+                "shopName" to "두 번째 가게"
+            )
+        }
+    }
+)

--- a/contract-stubs/META-INF/com.example.estdelivery.shop/shop/1.0-SNAPSHOT/contracts/shop/findShopOwnerByShopOwnerId.kts
+++ b/contract-stubs/META-INF/com.example.estdelivery.shop/shop/1.0-SNAPSHOT/contracts/shop/findShopOwnerByShopOwnerId.kts
@@ -1,0 +1,42 @@
+package shop
+
+import org.springframework.cloud.contract.spec.ContractDsl.Companion.contract
+
+listOf(
+    contract {
+        name = "get owner id is 1"
+        request {
+            method = GET
+            url = url("/owners/1")
+        }
+        response {
+            status = OK
+            headers {
+                contentType = "application/json"
+            }
+            body = body(
+                "shopOwnerId" to 1,
+                "shopId" to 1,
+                "shopName" to "첫 번째 가게"
+            )
+        }
+    },
+    contract {
+        name = "get owner id is 2"
+        request {
+            method = GET
+            url = url("/owners/2")
+        }
+        response {
+            status = OK
+            headers {
+                contentType = "application/json"
+            }
+            body = body(
+                "shopOwnerId" to 2,
+                "shopId" to 2,
+                "shopName" to "두 번째 가게"
+            )
+        }
+    }
+)

--- a/coupon/build.gradle.kts
+++ b/coupon/build.gradle.kts
@@ -1,4 +1,7 @@
-
 tasks.withType<Jar> {
     enabled = true
+}
+
+dependencies {
+    testImplementation("org.springframework.cloud:spring-cloud-starter-contract-stub-runner")
 }

--- a/coupon/build.gradle.kts
+++ b/coupon/build.gradle.kts
@@ -4,4 +4,5 @@ tasks.withType<Jar> {
 
 dependencies {
     testImplementation("org.springframework.cloud:spring-cloud-starter-contract-stub-runner")
+    testImplementation("org.springframework.cloud:spring-cloud-contract-spec-kotlin")
 }

--- a/coupon/src/main/kotlin/com/example/estdelivery/application/port/out/persistence/entity/MemberEntity.kt
+++ b/coupon/src/main/kotlin/com/example/estdelivery/application/port/out/persistence/entity/MemberEntity.kt
@@ -14,7 +14,9 @@ import jakarta.persistence.Table
 @Table(name = "member")
 class MemberEntity(
     var name: String,
-    @ManyToMany
+    @ManyToMany(
+        targetEntity = CouponEntity::class
+    )
     @JoinTable(
         name = "member_coupon_book",
         joinColumns = [JoinColumn(name = "member_id")],

--- a/coupon/src/main/kotlin/com/example/estdelivery/application/port/out/persistence/entity/ShopEntity.kt
+++ b/coupon/src/main/kotlin/com/example/estdelivery/application/port/out/persistence/entity/ShopEntity.kt
@@ -13,35 +13,45 @@ import jakarta.persistence.Table
 @Entity
 @Table(name = "shop")
 class ShopEntity(
-    @ManyToMany
+    @ManyToMany(
+        targetEntity = CouponEntity::class
+    )
     @JoinTable(
         name = "publish_coupon_book",
         joinColumns = [JoinColumn(name = "shop_id")],
         inverseJoinColumns = [JoinColumn(name = "coupon_id")],
     )
     val publishedCouponBook: List<CouponEntity>,
-    @ManyToMany
+    @ManyToMany(
+        targetEntity = CouponEntity::class
+    )
     @JoinTable(
         name = "publish_event_coupon_book",
         joinColumns = [JoinColumn(name = "shop_id")],
         inverseJoinColumns = [JoinColumn(name = "coupon_id")],
     )
     val publishedEventCouponBook: List<CouponEntity>,
-    @ManyToMany
+    @ManyToMany(
+        targetEntity = CouponEntity::class
+    )
     @JoinTable(
         name = "handout_coupon_book",
         joinColumns = [JoinColumn(name = "shop_id")],
         inverseJoinColumns = [JoinColumn(name = "coupon_id")],
     )
     var handOutCouponBook: List<CouponEntity>,
-    @ManyToMany
+    @ManyToMany(
+        targetEntity = CouponEntity::class
+    )
     @JoinTable(
         name = "use_coupon_book",
         joinColumns = [JoinColumn(name = "shop_id")],
         inverseJoinColumns = [JoinColumn(name = "coupon_id")],
     )
     var usedCouponBook: List<CouponEntity>,
-    @ManyToMany
+    @ManyToMany(
+        targetEntity = MemberEntity::class
+    )
     @JoinTable(
         name = "use_coupon_book",
         joinColumns = [JoinColumn(name = "shop_id")],

--- a/coupon/src/main/kotlin/com/example/estdelivery/application/port/out/persistence/repository/ShopOwnerRepository.kt
+++ b/coupon/src/main/kotlin/com/example/estdelivery/application/port/out/persistence/repository/ShopOwnerRepository.kt
@@ -2,8 +2,8 @@ package com.example.estdelivery.application.port.out.persistence.repository
 
 import com.example.estdelivery.application.port.out.persistence.entity.ShopEntity
 import com.example.estdelivery.application.port.out.persistence.entity.ShopOwnerEntity
-import org.springframework.data.jpa.repository.JpaRepository
 import java.util.Optional
+import org.springframework.data.jpa.repository.JpaRepository
 
 interface ShopOwnerRepository : JpaRepository<ShopOwnerEntity, Long> {
     fun findByShopEntity(shopEntity: ShopEntity): Optional<ShopOwnerEntity>

--- a/coupon/src/main/kotlin/com/example/estdelivery/domain/shop/Shop.kt
+++ b/coupon/src/main/kotlin/com/example/estdelivery/domain/shop/Shop.kt
@@ -22,8 +22,8 @@ class Shop(
             coupon,
             CouponBook(
                 publishedCoupons.showPublishedCoupons() +
-                    handOutCouponBook.showHandOutCoupon() +
-                    publishedEventCoupons.showEventCoupons(),
+                        handOutCouponBook.showHandOutCoupon() +
+                        publishedEventCoupons.showEventCoupons(),
             ),
         )
     }

--- a/coupon/src/test/kotlin/com/example/estdelivery/EstDeliveryCouponApplicationTests.kt
+++ b/coupon/src/test/kotlin/com/example/estdelivery/EstDeliveryCouponApplicationTests.kt
@@ -6,5 +6,6 @@ import org.springframework.boot.test.context.SpringBootTest
 @SpringBootTest
 class EstDeliveryCouponApplicationTests {
     @Test
-    fun contextLoads() {}
+    fun contextLoads() {
+    }
 }

--- a/coupon/src/test/kotlin/com/example/estdelivery/application/IssueRandomCouponServiceTest.kt
+++ b/coupon/src/test/kotlin/com/example/estdelivery/application/IssueRandomCouponServiceTest.kt
@@ -66,14 +66,14 @@ class IssueRandomCouponServiceTest : FreeSpec({
             isProgress = true,
             disCountType = EventDiscountType.FIXED,
             probabilityRanges =
-                DiscountAmountProbability(
-                    listOf(
-                        ProbabilityRange(1000, 1500, 0.5),
-                        ProbabilityRange(1200, 2000, 0.3),
-                        ProbabilityRange(2100, 3000, 0.2),
-                    ),
-                    DiscountRange(1000, 3000),
+            DiscountAmountProbability(
+                listOf(
+                    ProbabilityRange(1000, 1500, 0.5),
+                    ProbabilityRange(1200, 2000, 0.3),
+                    ProbabilityRange(2100, 3000, 0.2),
                 ),
+                DiscountRange(1000, 3000),
+            ),
             participatedMembers = emptyList(),
         )
     val 이벤트_쿠폰 = 이벤트_쿠폰

--- a/coupon/src/test/kotlin/com/example/estdelivery/application/port/out/persistence/CouponPersistenceAdapterTest.kt
+++ b/coupon/src/test/kotlin/com/example/estdelivery/application/port/out/persistence/CouponPersistenceAdapterTest.kt
@@ -9,7 +9,7 @@ import io.kotest.core.spec.style.FreeSpec
 import io.kotest.matchers.shouldBe
 import io.mockk.every
 import io.mockk.mockk
-import java.util.*
+import java.util.Optional
 
 class CouponPersistenceAdapterTest : FreeSpec({
     var couponRepository = mockk<CouponRepository>()

--- a/coupon/src/test/kotlin/com/example/estdelivery/application/port/out/persistence/MemberPersistenceAdapterTest.kt
+++ b/coupon/src/test/kotlin/com/example/estdelivery/application/port/out/persistence/MemberPersistenceAdapterTest.kt
@@ -10,7 +10,7 @@ import io.kotest.matchers.shouldBe
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
-import java.util.*
+import java.util.Optional
 
 class MemberPersistenceAdapterTest : FreeSpec({
 

--- a/coupon/src/test/kotlin/com/example/estdelivery/application/port/out/persistence/ShopOwnerPersistenceAdapterTest.kt
+++ b/coupon/src/test/kotlin/com/example/estdelivery/application/port/out/persistence/ShopOwnerPersistenceAdapterTest.kt
@@ -16,7 +16,7 @@ import io.kotest.matchers.shouldBe
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
-import java.util.*
+import java.util.Optional
 
 class ShopOwnerPersistenceAdapterTest : FreeSpec({
 

--- a/event/build.gradle.kts
+++ b/event/build.gradle.kts
@@ -1,3 +1,18 @@
+plugins {
+    id("org.springframework.cloud.contract") version "4.1.2"
+}
+
 tasks.withType<Jar> {
     enabled = true
+}
+
+dependencies {
+    testImplementation("org.springframework.cloud:spring-cloud-starter-contract-verifier")
+}
+
+tasks.contractTest {
+    useJUnitPlatform()
+}
+
+contracts {
 }

--- a/event/build.gradle.kts
+++ b/event/build.gradle.kts
@@ -1,6 +1,10 @@
+import org.springframework.cloud.contract.verifier.config.TestFramework.JUNIT5
+
 plugins {
     id("org.springframework.cloud.contract") version "4.1.2"
 }
+
+group = "com.example.estdelivery.event"
 
 tasks.withType<Jar> {
     enabled = true
@@ -8,11 +12,20 @@ tasks.withType<Jar> {
 
 dependencies {
     testImplementation("org.springframework.cloud:spring-cloud-starter-contract-verifier")
+    testImplementation("org.springframework.cloud:spring-cloud-contract-spec-kotlin")
 }
 
 tasks.contractTest {
     useJUnitPlatform()
 }
 
+tasks.withType<Delete> {
+    doFirst {
+        delete("~/.m2/repository/com/example/estdelivery/event")
+    }
+}
 contracts {
+    contractsDslDir.set(file("src/test/resources/contracts"))
+    testFramework.set(JUNIT5)
+    packageWithBaseClasses.set("com.example.estdelivery.event")
 }

--- a/event/build.gradle.kts
+++ b/event/build.gradle.kts
@@ -5,6 +5,7 @@ plugins {
 }
 
 group = "com.example.estdelivery.event"
+version = "1.0-SNAPSHOT"
 
 tasks.withType<Jar> {
     enabled = true
@@ -19,13 +20,9 @@ tasks.contractTest {
     useJUnitPlatform()
 }
 
-tasks.withType<Delete> {
-    doFirst {
-        delete("~/.m2/repository/com/example/estdelivery/event")
-    }
-}
 contracts {
     contractsDslDir.set(file("src/test/resources/contracts"))
     testFramework.set(JUNIT5)
     packageWithBaseClasses.set("com.example.estdelivery.event")
+    stubsOutputDir.set(file("../contract-stubs"))
 }

--- a/event/src/main/kotlin/com/example/estdelivery/event/EstDeliveryEventApplication.kt
+++ b/event/src/main/kotlin/com/example/estdelivery/event/EstDeliveryEventApplication.kt
@@ -1,4 +1,4 @@
-package com.example.estdelivery
+package com.example.estdelivery.event
 
 import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.boot.runApplication

--- a/event/src/main/kotlin/com/example/estdelivery/event/controller/EventController.kt
+++ b/event/src/main/kotlin/com/example/estdelivery/event/controller/EventController.kt
@@ -1,0 +1,28 @@
+package com.example.estdelivery.event.controller
+
+import com.example.estdelivery.event.dto.EventResponse
+import com.example.estdelivery.event.service.EventService
+import org.springframework.http.MediaType
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PutMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+class EventController(
+    private val eventService: EventService
+) {
+
+    @GetMapping(
+        value = ["/events/{id}"],
+        produces = [MediaType.APPLICATION_JSON_VALUE]
+    )
+    fun getEvent(@PathVariable id: Long): EventResponse {
+        return eventService.findById(id)
+    }
+
+    @PutMapping("/events/{id}/participants/{memberId}")
+    fun participateEvent(@PathVariable id: Long, @PathVariable memberId: Long) {
+        eventService.participate(id, memberId)
+    }
+}

--- a/event/src/main/kotlin/com/example/estdelivery/event/dto/EventResponse.kt
+++ b/event/src/main/kotlin/com/example/estdelivery/event/dto/EventResponse.kt
@@ -1,0 +1,15 @@
+package com.example.estdelivery.event.dto
+
+import com.example.estdelivery.event.entity.EventDiscountType
+import com.example.estdelivery.event.entity.ProbabilityRange
+
+data class EventResponse(
+    val id: Long,
+    val description: String,
+    val isProgress: Boolean,
+    val discountType: EventDiscountType,
+    val intervalsProbability: List<ProbabilityRange>,
+    val discountRangeMin: Int,
+    val discountRangeMax: Int,
+    val participatedMembers: List<Long>,
+)

--- a/event/src/main/kotlin/com/example/estdelivery/event/entity/Event.kt
+++ b/event/src/main/kotlin/com/example/estdelivery/event/entity/Event.kt
@@ -1,0 +1,33 @@
+package com.example.estdelivery.event.entity
+
+import jakarta.persistence.CascadeType
+import jakarta.persistence.CollectionTable
+import jakarta.persistence.Column
+import jakarta.persistence.ElementCollection
+import jakarta.persistence.Entity
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+import jakarta.persistence.JoinColumn
+import jakarta.persistence.OneToMany
+
+@Entity
+class Event(
+    val description: String,
+    val isProgress: Boolean,
+    val disCountType: EventDiscountType,
+    @OneToMany(mappedBy = "event", cascade = [CascadeType.ALL], orphanRemoval = true)
+    val intervalsProbability: List<ProbabilityRange>,
+    val disCountRangeMin: Int,
+    val disCountRangeMax: Int,
+    @ElementCollection
+    @CollectionTable(
+        name = "event_member",
+        joinColumns = [JoinColumn(name = "event_id")]
+    )
+    @Column(name = "member_id")
+    var participatedMembers: List<Long> = emptyList(),
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val id: Long,
+)

--- a/event/src/main/kotlin/com/example/estdelivery/event/entity/EventDiscountType.kt
+++ b/event/src/main/kotlin/com/example/estdelivery/event/entity/EventDiscountType.kt
@@ -1,0 +1,6 @@
+package com.example.estdelivery.event.entity
+
+enum class EventDiscountType {
+    RATE,
+    FIXED,
+}

--- a/event/src/main/kotlin/com/example/estdelivery/event/entity/ProbabilityRange.kt
+++ b/event/src/main/kotlin/com/example/estdelivery/event/entity/ProbabilityRange.kt
@@ -3,12 +3,17 @@ package com.example.estdelivery.event.entity
 import jakarta.persistence.Entity
 import jakarta.persistence.GeneratedValue
 import jakarta.persistence.Id
+import jakarta.persistence.JoinColumn
+import jakarta.persistence.ManyToOne
 
 @Entity
 class ProbabilityRange(
     val min: Int,
     val max: Int,
     val probability: Double,
+    @ManyToOne
+    @JoinColumn(name = "event_id")
+    val event: Event? = null,
     @Id
     @GeneratedValue
     val id: Long? = null,

--- a/event/src/main/kotlin/com/example/estdelivery/event/entity/ProbabilityRange.kt
+++ b/event/src/main/kotlin/com/example/estdelivery/event/entity/ProbabilityRange.kt
@@ -1,0 +1,21 @@
+package com.example.estdelivery.event.entity
+
+import jakarta.persistence.Entity
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.Id
+
+@Entity
+class ProbabilityRange(
+    val min: Int,
+    val max: Int,
+    val probability: Double,
+    @Id
+    @GeneratedValue
+    val id: Long? = null,
+) {
+    init {
+        require(min < max) { "min 은 max보다 작아야 합니다." }
+        require(min >= 0) { "min은 0보다 작을 수 없습니다." }
+        require(0.0 < probability && probability < 1.0) { "probability는 0보다 커야 하고 1보다 작아야 합니다." }
+    }
+}

--- a/event/src/main/kotlin/com/example/estdelivery/event/repository/EventRepository.kt
+++ b/event/src/main/kotlin/com/example/estdelivery/event/repository/EventRepository.kt
@@ -1,0 +1,6 @@
+package com.example.estdelivery.event.repository
+
+import com.example.estdelivery.event.entity.Event
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface EventRepository: JpaRepository<Event, Long>

--- a/event/src/main/kotlin/com/example/estdelivery/event/service/EventService.kt
+++ b/event/src/main/kotlin/com/example/estdelivery/event/service/EventService.kt
@@ -1,0 +1,33 @@
+package com.example.estdelivery.event.service
+
+import com.example.estdelivery.event.dto.EventResponse
+import com.example.estdelivery.event.repository.EventRepository
+import org.springframework.data.repository.findByIdOrNull
+import org.springframework.stereotype.Service
+
+@Service
+class EventService(
+    private val eventRepository: EventRepository,
+) {
+    fun findById(id: Long): EventResponse {
+        val event = eventRepository.findByIdOrNull(id)
+            ?: throw IllegalArgumentException("Event not found. id=$id")
+        return EventResponse(
+            id = event.id,
+            description = event.description,
+            isProgress = event.isProgress,
+            discountType = event.disCountType,
+            discountRangeMin = event.disCountRangeMin,
+            discountRangeMax = event.disCountRangeMax,
+            intervalsProbability = event.intervalsProbability,
+            participatedMembers = event.participatedMembers,
+        )
+    }
+
+    fun participate(id: Long, memberId: Long) {
+        val event = eventRepository.findByIdOrNull(id)
+            ?: throw IllegalArgumentException("Event not found. id=$id")
+        event.participatedMembers += memberId
+        eventRepository.save(event)
+    }
+}

--- a/event/src/test/kotlin/com/example/estdelivery/event/EstDeliveryEventApplicationKtTest.kt
+++ b/event/src/test/kotlin/com/example/estdelivery/event/EstDeliveryEventApplicationKtTest.kt
@@ -1,4 +1,4 @@
-package com.example.estdelivery
+package com.example.estdelivery.event
 
 import org.junit.jupiter.api.Test
 import org.springframework.boot.test.context.SpringBootTest

--- a/event/src/test/kotlin/com/example/estdelivery/event/EventBase.kt
+++ b/event/src/test/kotlin/com/example/estdelivery/event/EventBase.kt
@@ -1,0 +1,35 @@
+package com.example.estdelivery.event
+
+import com.example.estdelivery.event.controller.EventController
+import com.example.estdelivery.event.dto.EventResponse
+import com.example.estdelivery.event.entity.EventDiscountType
+import com.example.estdelivery.event.entity.ProbabilityRange
+import com.example.estdelivery.event.service.EventService
+import io.mockk.every
+import io.mockk.mockk
+import io.restassured.module.mockmvc.RestAssuredMockMvc
+import org.junit.jupiter.api.BeforeEach
+
+open class EventBase {
+    @BeforeEach
+    fun setup() {
+        val eventService = mockk<EventService>()
+        every { eventService.findById(1) } returns EventResponse(
+            1,
+            "이벤트 설명",
+            true,
+            EventDiscountType.FIXED,
+            listOf(
+                ProbabilityRange(1000, 1500, 0.5),
+                ProbabilityRange(1600, 2000, 0.3),
+                ProbabilityRange(2100, 2500, 0.2),
+            ),
+            1000,
+            2500,
+            listOf(1, 2, 3),
+        )
+
+        every { eventService.participate(1, 1) } returns Unit
+        RestAssuredMockMvc.standaloneSetup(EventController(eventService))
+    }
+}

--- a/event/src/test/resources/contracts/event/findEvent.kts
+++ b/event/src/test/resources/contracts/event/findEvent.kts
@@ -1,0 +1,42 @@
+package event
+
+import org.springframework.cloud.contract.spec.ContractDsl.Companion.contract
+
+contract {
+    request {
+        method = GET
+        url = url("/events/1")
+    }
+    response {
+        status = OK
+        headers {
+            contentType = "application/json"
+        }
+        body = body(
+            "id" to 1,
+            "description" to "이벤트 설명",
+            "isProgress" to true,
+            "discountType" to "FIXED",
+            "intervalsProbability" to listOf(
+                mapOf(
+                    "min" to 1000,
+                    "max" to 1500,
+                    "probability" to 0.5
+                ),
+                mapOf(
+                    "min" to 1600,
+                    "max" to 2000,
+                    "probability" to 0.3
+                ),
+                mapOf(
+                    "min" to 2100,
+                    "max" to 2500,
+                    "probability" to 0.2
+                )
+            ),
+            "discountRangeMin" to 1000,
+            "discountRangeMax" to 2500,
+            "participatedMembers" to listOf(1, 2, 3)
+        )
+    }
+}

--- a/event/src/test/resources/contracts/event/participateMember.kts
+++ b/event/src/test/resources/contracts/event/participateMember.kts
@@ -1,0 +1,12 @@
+
+import org.springframework.cloud.contract.spec.ContractDsl.Companion.contract
+
+contract {
+    request {
+        method = PUT
+        url = url("/events/1/participants/1")
+    }
+    response {
+        status = OK
+    }
+}

--- a/member/build.gradle.kts
+++ b/member/build.gradle.kts
@@ -1,6 +1,10 @@
+import org.springframework.cloud.contract.verifier.config.TestFramework.JUNIT5
+
 plugins {
     id("org.springframework.cloud.contract") version "4.1.2"
 }
+
+group = "com.example.estdelivery.member"
 
 tasks.withType<Jar> {
     enabled = true
@@ -8,6 +12,7 @@ tasks.withType<Jar> {
 
 dependencies {
     testImplementation("org.springframework.cloud:spring-cloud-starter-contract-verifier")
+    testImplementation("org.springframework.cloud:spring-cloud-contract-spec-kotlin")
 }
 
 tasks.contractTest {
@@ -15,4 +20,13 @@ tasks.contractTest {
 }
 
 contracts {
+    contractsDslDir.set(file("src/test/resources/contracts"))
+    testFramework.set(JUNIT5)
+    packageWithBaseClasses.set("com.example.estdelivery.member")
+}
+
+tasks.withType<Delete> {
+    doFirst {
+        delete("~/.m2/repository/com/example/estdelivery/member")
+    }
 }

--- a/member/build.gradle.kts
+++ b/member/build.gradle.kts
@@ -1,3 +1,18 @@
+plugins {
+    id("org.springframework.cloud.contract") version "4.1.2"
+}
+
 tasks.withType<Jar> {
     enabled = true
+}
+
+dependencies {
+    testImplementation("org.springframework.cloud:spring-cloud-starter-contract-verifier")
+}
+
+tasks.contractTest {
+    useJUnitPlatform()
+}
+
+contracts {
 }

--- a/member/build.gradle.kts
+++ b/member/build.gradle.kts
@@ -5,6 +5,7 @@ plugins {
 }
 
 group = "com.example.estdelivery.member"
+version = "1.0-SNAPSHOT"
 
 tasks.withType<Jar> {
     enabled = true
@@ -23,6 +24,7 @@ contracts {
     contractsDslDir.set(file("src/test/resources/contracts"))
     testFramework.set(JUNIT5)
     packageWithBaseClasses.set("com.example.estdelivery.member")
+    stubsOutputDir.set(file("../contract-stubs"))
 }
 
 tasks.withType<Delete> {

--- a/member/src/main/kotlin/com/example/estdelivery/member/EstDeliveryMemberApplication.kt
+++ b/member/src/main/kotlin/com/example/estdelivery/member/EstDeliveryMemberApplication.kt
@@ -1,4 +1,4 @@
-package com.example.estdelivery
+package com.example.estdelivery.member
 
 import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.boot.runApplication

--- a/member/src/main/kotlin/com/example/estdelivery/member/controller/MemberController.kt
+++ b/member/src/main/kotlin/com/example/estdelivery/member/controller/MemberController.kt
@@ -1,0 +1,22 @@
+package com.example.estdelivery.member.controller
+
+import com.example.estdelivery.member.dto.MemberResponse
+import com.example.estdelivery.member.service.MemberService
+import org.springframework.http.MediaType
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+class MemberController(
+    private val memberService: MemberService,
+) {
+
+    @GetMapping(
+        value = ["/members/{id}"],
+        produces = [MediaType.APPLICATION_JSON_VALUE],
+    )
+    fun findMember(@PathVariable id: Long): MemberResponse {
+        return memberService.findMemberById(id)
+    }
+}

--- a/member/src/main/kotlin/com/example/estdelivery/member/dto/MemberResponse.kt
+++ b/member/src/main/kotlin/com/example/estdelivery/member/dto/MemberResponse.kt
@@ -1,0 +1,6 @@
+package com.example.estdelivery.member.dto
+
+data class MemberResponse(
+    val id: Long,
+    val name: String,
+)

--- a/member/src/main/kotlin/com/example/estdelivery/member/entiry/Member.kt
+++ b/member/src/main/kotlin/com/example/estdelivery/member/entiry/Member.kt
@@ -1,0 +1,16 @@
+package com.example.estdelivery.member.entiry
+
+import jakarta.persistence.Entity
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+
+@Entity
+class Member(
+    val name: String,
+    val email: String,
+    val password: String,
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val id: Long? = null,
+)

--- a/member/src/main/kotlin/com/example/estdelivery/member/repository/MemberRepository.kt
+++ b/member/src/main/kotlin/com/example/estdelivery/member/repository/MemberRepository.kt
@@ -1,0 +1,7 @@
+package com.example.estdelivery.member.repository
+
+import com.example.estdelivery.member.entiry.Member
+import java.util.Optional
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface MemberRepository : JpaRepository<Member, Long>

--- a/member/src/main/kotlin/com/example/estdelivery/member/service/MemberService.kt
+++ b/member/src/main/kotlin/com/example/estdelivery/member/service/MemberService.kt
@@ -1,0 +1,18 @@
+package com.example.estdelivery.member.service
+
+import com.example.estdelivery.member.dto.MemberResponse
+import com.example.estdelivery.member.repository.MemberRepository
+import org.springframework.data.repository.findByIdOrNull
+import org.springframework.stereotype.Service
+
+@Service
+class MemberService(
+    private val memberRepository: MemberRepository,
+) {
+    fun findMemberById(id: Long): MemberResponse {
+        val member = memberRepository.findByIdOrNull(id)
+            ?: throw IllegalArgumentException("Member not found")
+        check(member.id == id) { "Member id mismatch" }
+        return MemberResponse(id, member.name)
+    }
+}

--- a/member/src/test/kotlin/com/example/estdelivery/member/EstDeliveryMemberApplicationKtTest.kt
+++ b/member/src/test/kotlin/com/example/estdelivery/member/EstDeliveryMemberApplicationKtTest.kt
@@ -1,10 +1,10 @@
-package com.example.estdelivery
+package com.example.estdelivery.member
 
 import org.junit.jupiter.api.Test
 import org.springframework.boot.test.context.SpringBootTest
 
 @SpringBootTest
-class EstDeliveryShopApplicationKtTest {
+class EstDeliveryMemberApplicationKtTest {
     @Test
     fun contextLoads() {
     }

--- a/member/src/test/kotlin/com/example/estdelivery/member/MemberBase.kt
+++ b/member/src/test/kotlin/com/example/estdelivery/member/MemberBase.kt
@@ -1,0 +1,18 @@
+package com.example.estdelivery.member
+
+import com.example.estdelivery.member.controller.MemberController
+import com.example.estdelivery.member.dto.MemberResponse
+import com.example.estdelivery.member.service.MemberService
+import io.mockk.every
+import io.mockk.mockk
+import io.restassured.module.mockmvc.RestAssuredMockMvc
+import org.junit.jupiter.api.BeforeEach
+
+open class MemberBase {
+    @BeforeEach
+    fun setup() {
+        val memberService = mockk<MemberService>()
+        every { memberService.findMemberById(1) } returns MemberResponse(1, "이건창")
+        RestAssuredMockMvc.standaloneSetup(MemberController(memberService))
+    }
+}

--- a/member/src/test/resources/contracts/member/findMember.kts
+++ b/member/src/test/resources/contracts/member/findMember.kts
@@ -1,0 +1,20 @@
+package member
+
+import org.springframework.cloud.contract.spec.ContractDsl.Companion.contract
+
+contract {
+    request {
+        method = GET
+        url = url(v(consumer(regex("\\/members\\/[0-9]{1,10}")), producer("/members/1")))
+    }
+    response {
+        status = OK
+        headers {
+            contentType = "application/json"
+        }
+        body = body(
+            "id" to 1,
+            "name" to "이건창"
+        )
+    }
+}

--- a/shop/build.gradle.kts
+++ b/shop/build.gradle.kts
@@ -1,3 +1,18 @@
+plugins {
+    id("org.springframework.cloud.contract") version "4.1.2"
+}
+
 tasks.withType<Jar> {
     enabled = true
+}
+
+dependencies {
+    testImplementation("org.springframework.cloud:spring-cloud-starter-contract-verifier")
+}
+
+tasks.contractTest {
+    useJUnitPlatform()
+}
+
+contracts {
 }

--- a/shop/build.gradle.kts
+++ b/shop/build.gradle.kts
@@ -1,6 +1,10 @@
+import org.springframework.cloud.contract.verifier.config.TestFramework.JUNIT5
+
 plugins {
     id("org.springframework.cloud.contract") version "4.1.2"
 }
+
+group = "com.example.estdelivery.shop"
 
 tasks.withType<Jar> {
     enabled = true
@@ -8,11 +12,21 @@ tasks.withType<Jar> {
 
 dependencies {
     testImplementation("org.springframework.cloud:spring-cloud-starter-contract-verifier")
+    testImplementation("org.springframework.cloud:spring-cloud-contract-spec-kotlin")
 }
 
 tasks.contractTest {
     useJUnitPlatform()
 }
 
+tasks.withType<Delete> {
+    doFirst {
+        delete("~/.m2/repository/com/example/estdelivery/shop")
+    }
+}
+
 contracts {
+    contractsDslDir.set(file("src/test/resources/contracts"))
+    testFramework.set(JUNIT5)
+    packageWithBaseClasses.set("com.example.estdelivery.shop")
 }

--- a/shop/build.gradle.kts
+++ b/shop/build.gradle.kts
@@ -5,6 +5,7 @@ plugins {
 }
 
 group = "com.example.estdelivery.shop"
+version = "1.0-SNAPSHOT"
 
 tasks.withType<Jar> {
     enabled = true
@@ -19,14 +20,9 @@ tasks.contractTest {
     useJUnitPlatform()
 }
 
-tasks.withType<Delete> {
-    doFirst {
-        delete("~/.m2/repository/com/example/estdelivery/shop")
-    }
-}
-
 contracts {
     contractsDslDir.set(file("src/test/resources/contracts"))
     testFramework.set(JUNIT5)
     packageWithBaseClasses.set("com.example.estdelivery.shop")
+    stubsOutputDir.set(file("../contract-stubs"))
 }

--- a/shop/src/main/kotlin/com/example/estdelivery/shop/EstDeliveryShopApplication.kt
+++ b/shop/src/main/kotlin/com/example/estdelivery/shop/EstDeliveryShopApplication.kt
@@ -1,4 +1,4 @@
-package com.example.estdelivery
+package com.example.estdelivery.shop
 
 import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.boot.runApplication

--- a/shop/src/main/kotlin/com/example/estdelivery/shop/controller/ShopOwnerController.kt
+++ b/shop/src/main/kotlin/com/example/estdelivery/shop/controller/ShopOwnerController.kt
@@ -1,0 +1,24 @@
+package com.example.estdelivery.shop.controller
+
+import com.example.estdelivery.shop.service.ShopOwnerService
+import org.springframework.http.MediaType
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+class ShopOwnerController(
+    private val shopOwnerService: ShopOwnerService,
+) {
+    @GetMapping(
+        value = ["/owners/{id}"],
+        produces = [MediaType.APPLICATION_JSON_VALUE]
+    )
+    fun findShopOwner(@PathVariable id: Long) = shopOwnerService.findShopOwnerById(id)
+
+    @GetMapping(
+        value = ["/owners/shop/{id}"],
+        produces = [MediaType.APPLICATION_JSON_VALUE]
+    )
+    fun findShopOwnerByShopId(@PathVariable id: Long) = shopOwnerService.findShopOwnerByShopId(id)
+}

--- a/shop/src/main/kotlin/com/example/estdelivery/shop/dto/ShopOwnerResponse.kt
+++ b/shop/src/main/kotlin/com/example/estdelivery/shop/dto/ShopOwnerResponse.kt
@@ -1,0 +1,7 @@
+package com.example.estdelivery.shop.dto
+
+data class ShopOwnerResponse(
+    val shopOwnerId: Long,
+    val shopId: Long,
+    val shopName: String,
+)

--- a/shop/src/main/kotlin/com/example/estdelivery/shop/entity/Shop.kt
+++ b/shop/src/main/kotlin/com/example/estdelivery/shop/entity/Shop.kt
@@ -1,0 +1,19 @@
+package com.example.estdelivery.shop.entity
+
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+import jakarta.persistence.Table
+
+
+@Entity
+@Table(name = "shop")
+class Shop(
+    var name: String,
+    @Id
+    @Column(name = "shop_id")
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val id: Long? = null,
+)

--- a/shop/src/main/kotlin/com/example/estdelivery/shop/entity/ShopOwner.kt
+++ b/shop/src/main/kotlin/com/example/estdelivery/shop/entity/ShopOwner.kt
@@ -1,0 +1,20 @@
+package com.example.estdelivery.shop.entity
+
+import jakarta.persistence.Entity
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+import jakarta.persistence.JoinColumn
+import jakarta.persistence.OneToOne
+import jakarta.persistence.Table
+
+@Entity
+@Table(name = "shop_owner")
+class ShopOwner(
+    @OneToOne
+    @JoinColumn(name = "shop_id")
+    var shop: Shop,
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    var id: Long? = null,
+)

--- a/shop/src/main/kotlin/com/example/estdelivery/shop/repository/ShopOwnerRepository.kt
+++ b/shop/src/main/kotlin/com/example/estdelivery/shop/repository/ShopOwnerRepository.kt
@@ -1,0 +1,8 @@
+package com.example.estdelivery.shop.repository
+
+import com.example.estdelivery.shop.entity.ShopOwner
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface ShopOwnerRepository: JpaRepository<ShopOwner, Long> {
+    fun findByShopId(shopId: Long): ShopOwner?
+}

--- a/shop/src/main/kotlin/com/example/estdelivery/shop/service/ShopOwnerService.kt
+++ b/shop/src/main/kotlin/com/example/estdelivery/shop/service/ShopOwnerService.kt
@@ -1,0 +1,40 @@
+package com.example.estdelivery.shop.service
+
+import com.example.estdelivery.shop.dto.ShopOwnerResponse
+import com.example.estdelivery.shop.repository.ShopOwnerRepository
+import org.springframework.data.repository.findByIdOrNull
+import org.springframework.stereotype.Service
+
+@Service
+class ShopOwnerService(
+    private val shopOwnerRepository: ShopOwnerRepository,
+) {
+    fun findShopOwnerById(id: Long): ShopOwnerResponse {
+        val shopOwner = shopOwnerRepository.findByIdOrNull(id)
+            ?: throw IllegalArgumentException("Shop owner not found")
+
+        check(shopOwner.shop.id == id) { "Shop owner with id $id is not a shop owner" }
+        check(shopOwner.shop.id != null) { "Shop owner with id $id has no shop id" }
+
+        return ShopOwnerResponse(
+            shopOwnerId = id,
+            shopId = shopOwner.shop.id!!,
+            shopName = shopOwner.shop.name,
+        )
+    }
+
+    fun findShopOwnerByShopId(shopId: Long): ShopOwnerResponse {
+        val shopOwner = shopOwnerRepository.findByShopId(shopId)
+            ?: throw IllegalArgumentException("Shop owner not found")
+
+        check(shopOwner.shop.id == shopId) { "Shop owner with shop id $shopId is not a shop owner" }
+        check(shopOwner.shop.id != null) { "Shop owner with shop id $shopId has no shop id" }
+        check(shopOwner.id != null) { "Shop owner with shop id $shopId has no shop owner id" }
+
+        return ShopOwnerResponse(
+            shopOwnerId = shopOwner.id!!,
+            shopId = shopOwner.shop.id!!,
+            shopName = shopOwner.shop.name,
+        )
+    }
+}

--- a/shop/src/test/kotlin/com/example/estdelivery/shop/EstDeliveryShopApplicationKtTest.kt
+++ b/shop/src/test/kotlin/com/example/estdelivery/shop/EstDeliveryShopApplicationKtTest.kt
@@ -1,4 +1,4 @@
-package com.example.estdelivery
+package com.example.estdelivery.shop
 
 import org.junit.jupiter.api.Test
 import org.springframework.boot.test.context.SpringBootTest

--- a/shop/src/test/kotlin/com/example/estdelivery/shop/ShopBase.kt
+++ b/shop/src/test/kotlin/com/example/estdelivery/shop/ShopBase.kt
@@ -1,0 +1,21 @@
+package com.example.estdelivery.shop
+
+import com.example.estdelivery.shop.controller.ShopOwnerController
+import com.example.estdelivery.shop.dto.ShopOwnerResponse
+import com.example.estdelivery.shop.service.ShopOwnerService
+import io.mockk.every
+import io.mockk.mockk
+import io.restassured.module.mockmvc.RestAssuredMockMvc
+import org.junit.jupiter.api.BeforeEach
+
+open class ShopBase {
+    @BeforeEach
+    fun setup() {
+        val shopOwnerService = mockk<ShopOwnerService>()
+        every { shopOwnerService.findShopOwnerById(1) } returns ShopOwnerResponse(1, 1, "첫 번째 가게")
+        every { shopOwnerService.findShopOwnerById(2) } returns ShopOwnerResponse(2, 2, "두 번째 가게")
+        every { shopOwnerService.findShopOwnerByShopId(1) } returns ShopOwnerResponse(1, 1, "첫 번째 가게")
+        every { shopOwnerService.findShopOwnerByShopId(2) } returns ShopOwnerResponse(2, 2, "두 번째 가게")
+        RestAssuredMockMvc.standaloneSetup(ShopOwnerController(shopOwnerService))
+    }
+}

--- a/shop/src/test/resources/contracts/shop/findShopOwnerByShopId.kts
+++ b/shop/src/test/resources/contracts/shop/findShopOwnerByShopId.kts
@@ -1,0 +1,42 @@
+package shop
+
+import org.springframework.cloud.contract.spec.ContractDsl.Companion.contract
+
+listOf(
+    contract {
+        name = "get owner shop id is 1"
+        request {
+            method = GET
+            url = url("/owners/shop/1")
+        }
+        response {
+            status = OK
+            headers {
+                contentType = "application/json"
+            }
+            body = body(
+                "shopOwnerId" to 1,
+                "shopId" to 1,
+                "shopName" to "첫 번째 가게"
+            )
+        }
+    },
+    contract {
+        name = "get owner shop id is 2"
+        request {
+            method = GET
+            url = url("/owners/shop/2")
+        }
+        response {
+            status = OK
+            headers {
+                contentType = "application/json"
+            }
+            body = body(
+                "shopOwnerId" to 2,
+                "shopId" to 2,
+                "shopName" to "두 번째 가게"
+            )
+        }
+    }
+)

--- a/shop/src/test/resources/contracts/shop/findShopOwnerByShopOwnerId.kts
+++ b/shop/src/test/resources/contracts/shop/findShopOwnerByShopOwnerId.kts
@@ -1,0 +1,42 @@
+package shop
+
+import org.springframework.cloud.contract.spec.ContractDsl.Companion.contract
+
+listOf(
+    contract {
+        name = "get owner id is 1"
+        request {
+            method = GET
+            url = url("/owners/1")
+        }
+        response {
+            status = OK
+            headers {
+                contentType = "application/json"
+            }
+            body = body(
+                "shopOwnerId" to 1,
+                "shopId" to 1,
+                "shopName" to "첫 번째 가게"
+            )
+        }
+    },
+    contract {
+        name = "get owner id is 2"
+        request {
+            method = GET
+            url = url("/owners/2")
+        }
+        response {
+            status = OK
+            headers {
+                contentType = "application/json"
+            }
+            body = body(
+                "shopOwnerId" to 2,
+                "shopId" to 2,
+                "shopName" to "두 번째 가게"
+            )
+        }
+    }
+)


### PR DESCRIPTION
### Summary

- MSA 환경에서 헥사고날을 경험하기 위해 멀티 모듈로 변경하고 contract 자동화를 진행합니다.

### Description

- 책임을 분리하기 위해 멀티 모듈로 변경합니다.
  - 쿠폰 외 타도메인을 관리하면서 집중 대상이 불명확해졌습니다.
  - 분리하지 않으면 관리에 급급해져 쿠폰이라는 특징을 활용하기 어려워 보였습니다.
- contract를 자동화합니다.
  - 여러 멀티 모듈로 분산되면서 연결될 인프라가 많아졌습니다.
  - API 스펙을 관리하지 않으려고 계약서를 작성했습니다.
  - 버전 변동에 유연한 계약서 자동화를 구축합니다.