### PR TITLE
계약서를 개선한다

### DIFF
--- a/event/src/main/kotlin/com/example/estdelivery/event/controller/EventExceptionHandler.kt
+++ b/event/src/main/kotlin/com/example/estdelivery/event/controller/EventExceptionHandler.kt
@@ -1,0 +1,13 @@
+package com.example.estdelivery.event.controller
+
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.ExceptionHandler
+import org.springframework.web.bind.annotation.RestControllerAdvice
+
+@RestControllerAdvice
+class EventExceptionHandler {
+    @ExceptionHandler(IllegalArgumentException::class)
+    fun handleIllegalArgumentException(e: IllegalArgumentException): ResponseEntity<Void> {
+        return ResponseEntity.badRequest().build()
+    }
+}

--- a/event/src/test/kotlin/com/example/estdelivery/event/EventBase.kt
+++ b/event/src/test/kotlin/com/example/estdelivery/event/EventBase.kt
@@ -1,24 +1,35 @@
 package com.example.estdelivery.event
 
-import com.example.estdelivery.event.controller.EventController
 import com.example.estdelivery.event.dto.EventResponse
 import com.example.estdelivery.event.entity.EventDiscountType
 import com.example.estdelivery.event.entity.ProbabilityRange
 import com.example.estdelivery.event.service.EventService
+import com.ninjasquad.springmockk.MockkBean
 import io.mockk.every
-import io.mockk.mockk
-import io.mockk.slot
 import io.restassured.module.mockmvc.RestAssuredMockMvc
 import org.junit.jupiter.api.BeforeEach
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.web.context.WebApplicationContext
 
+@SpringBootTest
 open class EventBase {
+    @Autowired
+    lateinit var context: WebApplicationContext
+
+    @MockkBean
+    lateinit var eventService: EventService
+
     @BeforeEach
     fun setup() {
-        val eventService = mockk<EventService>()
-        val id = slot<Long>()
-        every { eventService.findById(capture(id)) } answers {
+        every { eventService.findById(any()) } answers {
+            val capturedId = firstArg<Long>()
+            if (capturedId % 2 == 0L) {
+                throw IllegalArgumentException("Invalid id")
+            }
+
             EventResponse(
-                id.captured,
+                capturedId,
                 "이벤트 설명",
                 true,
                 EventDiscountType.FIXED,
@@ -33,7 +44,12 @@ open class EventBase {
             )
         }
 
-        every { eventService.participate(any(), any()) } returns Unit
-        RestAssuredMockMvc.standaloneSetup(EventController(eventService))
+        every { eventService.participate(any(), any()) } answers {
+            if (secondArg<Long>() % 2 == 0L) {
+                throw IllegalArgumentException("Invalid id")
+            }
+        }
+
+        RestAssuredMockMvc.webAppContextSetup(this.context)
     }
 }

--- a/event/src/test/resources/contracts/event/findEvent.kts
+++ b/event/src/test/resources/contracts/event/findEvent.kts
@@ -2,41 +2,52 @@ package event
 
 import org.springframework.cloud.contract.spec.ContractDsl.Companion.contract
 
-contract {
-    request {
-        method = GET
-        url = url(v(regex("/events/[0-9]{1,9}")))
-    }
-    response {
-        status = OK
-        headers {
-            contentType = "application/json"
+arrayOf(
+    contract {
+        request {
+            method = GET
+            url = url(v(regex("\\/events\\/[0-9]{1,7}[13579]")))
         }
-        body = body(
-            "id" to value("${fromRequest().path(1)}"),
-            "description" to "이벤트 설명",
-            "isProgress" to true,
-            "discountType" to "FIXED",
-            "intervalsProbability" to listOf(
-                mapOf(
-                    "min" to 1000,
-                    "max" to 1500,
-                    "probability" to 0.5
+        response {
+            status = OK
+            headers {
+                contentType = "application/json"
+            }
+            body = body(
+                "id" to value("${fromRequest().path(1)}"),
+                "description" to "이벤트 설명",
+                "isProgress" to true,
+                "discountType" to "FIXED",
+                "intervalsProbability" to listOf(
+                    mapOf(
+                        "min" to 1000,
+                        "max" to 1500,
+                        "probability" to 0.5
+                    ),
+                    mapOf(
+                        "min" to 1600,
+                        "max" to 2000,
+                        "probability" to 0.3
+                    ),
+                    mapOf(
+                        "min" to 2100,
+                        "max" to 2500,
+                        "probability" to 0.2
+                    )
                 ),
-                mapOf(
-                    "min" to 1600,
-                    "max" to 2000,
-                    "probability" to 0.3
-                ),
-                mapOf(
-                    "min" to 2100,
-                    "max" to 2500,
-                    "probability" to 0.2
-                )
-            ),
-            "discountRangeMin" to 1000,
-            "discountRangeMax" to 2500,
-            "participatedMembers" to listOf(1, 2, 3)
-        )
+                "discountRangeMin" to 1000,
+                "discountRangeMax" to 2500,
+                "participatedMembers" to listOf(1, 2, 3)
+            )
+        }
+    },
+    contract {
+        request {
+            method = GET
+            url = url(v(regex("\\/events\\/[0-9]{1,7}[02468]")))
+        }
+        response {
+            status = BAD_REQUEST
+        }
     }
-}
+)

--- a/event/src/test/resources/contracts/event/participateMember.kts
+++ b/event/src/test/resources/contracts/event/participateMember.kts
@@ -1,12 +1,22 @@
-
 import org.springframework.cloud.contract.spec.ContractDsl.Companion.contract
 
-contract {
-    request {
-        method = PUT
-        url = url(v(regex("/events/[0-9]{1,9}/participants/[0-9]{1,9}")))
+arrayOf(
+    contract {
+        request {
+            method = PUT
+            url = url(v(regex("\\/events\\/[0-9]{1,9}\\/participants\\/[0-9]{1,7}[13579]")))
+        }
+        response {
+            status = OK
+        }
+    },
+    contract {
+        request {
+            method = PUT
+            url = url(v(regex("\\/events\\/[0-9]{1,9}\\/participants\\/[0-9]{1,7}[02468]")))
+        }
+        response {
+            status = BAD_REQUEST
+        }
     }
-    response {
-        status = OK
-    }
-}
+)

--- a/member/src/main/kotlin/com/example/estdelivery/member/controller/MemberExceptionHandler.kt
+++ b/member/src/main/kotlin/com/example/estdelivery/member/controller/MemberExceptionHandler.kt
@@ -1,0 +1,13 @@
+package com.example.estdelivery.member.controller
+
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.ExceptionHandler
+import org.springframework.web.bind.annotation.RestControllerAdvice
+
+@RestControllerAdvice
+class MemberExceptionHandler {
+    @ExceptionHandler(IllegalArgumentException::class)
+    fun handleIllegalArgumentException(e: IllegalArgumentException): ResponseEntity<Void> {
+        return ResponseEntity.badRequest().build()
+    }
+}

--- a/member/src/test/kotlin/com/example/estdelivery/member/MemberBase.kt
+++ b/member/src/test/kotlin/com/example/estdelivery/member/MemberBase.kt
@@ -1,20 +1,34 @@
 package com.example.estdelivery.member
 
-import com.example.estdelivery.member.controller.MemberController
 import com.example.estdelivery.member.dto.MemberResponse
 import com.example.estdelivery.member.service.MemberService
+import com.ninjasquad.springmockk.MockkBean
 import io.mockk.every
-import io.mockk.mockk
 import io.mockk.slot
 import io.restassured.module.mockmvc.RestAssuredMockMvc
 import org.junit.jupiter.api.BeforeEach
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.web.context.WebApplicationContext
 
+@SpringBootTest
 open class MemberBase {
+    @Autowired
+    lateinit var context: WebApplicationContext
+
+    @MockkBean
+    lateinit var memberService: MemberService
+
     @BeforeEach
     fun setup() {
-        val memberService = mockk<MemberService>()
         val id = slot<Long>()
-        every { memberService.findMemberById(capture(id)) } answers { MemberResponse(id.captured, "이건창") }
-        RestAssuredMockMvc.standaloneSetup(MemberController(memberService))
+        every { memberService.findMemberById(capture(id)) } answers {
+            if (id.captured % 2 == 0L) {
+                throw IllegalArgumentException("Invalid id")
+            }
+            MemberResponse(id.captured, "이건창")
+        }
+
+        RestAssuredMockMvc.webAppContextSetup(this.context)
     }
 }

--- a/member/src/test/kotlin/com/example/estdelivery/member/MemberBase.kt
+++ b/member/src/test/kotlin/com/example/estdelivery/member/MemberBase.kt
@@ -21,12 +21,12 @@ open class MemberBase {
 
     @BeforeEach
     fun setup() {
-        val id = slot<Long>()
-        every { memberService.findMemberById(capture(id)) } answers {
-            if (id.captured % 2 == 0L) {
+        every { memberService.findMemberById(any()) } answers {
+            val capturedId = firstArg<Long>()
+            if (capturedId % 2 == 0L) {
                 throw IllegalArgumentException("Invalid id")
             }
-            MemberResponse(id.captured, "이건창")
+            MemberResponse(capturedId, "이건창")
         }
 
         RestAssuredMockMvc.webAppContextSetup(this.context)

--- a/member/src/test/resources/contracts/member/findMember.kts
+++ b/member/src/test/resources/contracts/member/findMember.kts
@@ -2,19 +2,30 @@ package member
 
 import org.springframework.cloud.contract.spec.ContractDsl.Companion.contract
 
-contract {
-    request {
-        method = GET
-        url = url(v(regex("\\/members\\/[0-9]{1,10}")))
-    }
-    response {
-        status = OK
-        headers {
-            contentType = "application/json"
+arrayOf(
+    contract {
+        request {
+            method = GET
+            url = url(v(regex("\\/members\\/[0-9]{1,7}[13579]")))
         }
-        body = body(
-            "id" to value("${fromRequest().path(1)}"),
-            "name" to "이건창"
-        )
+        response {
+            status = OK
+            headers {
+                contentType = "application/json"
+            }
+            body = body(
+                "id" to value("${fromRequest().path(1)}"),
+                "name" to "이건창"
+            )
+        }
+    },
+    contract {
+        request {
+            method = GET
+            url = url(v(regex("\\/members\\/[0-9]{1,7}[02468]")))
+        }
+        response {
+            status = BAD_REQUEST
+        }
     }
-}
+)

--- a/shop/src/main/kotlin/com/example/estdelivery/shop/controller/ShopExceptionHandler.kt
+++ b/shop/src/main/kotlin/com/example/estdelivery/shop/controller/ShopExceptionHandler.kt
@@ -1,0 +1,13 @@
+package com.example.estdelivery.shop.controller
+
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.ExceptionHandler
+import org.springframework.web.bind.annotation.RestControllerAdvice
+
+@RestControllerAdvice
+class ShopExceptionHandler {
+    @ExceptionHandler(IllegalArgumentException::class)
+    fun handleIllegalArgumentException(e: IllegalArgumentException): ResponseEntity<Void> {
+        return ResponseEntity.badRequest().build()
+    }
+}

--- a/shop/src/test/kotlin/com/example/estdelivery/shop/ShopBase.kt
+++ b/shop/src/test/kotlin/com/example/estdelivery/shop/ShopBase.kt
@@ -1,33 +1,54 @@
 package com.example.estdelivery.shop
 
-import com.example.estdelivery.shop.controller.ShopOwnerController
 import com.example.estdelivery.shop.dto.ShopOwnerResponse
 import com.example.estdelivery.shop.dto.ShopResponse
 import com.example.estdelivery.shop.service.ShopOwnerService
+import com.ninjasquad.springmockk.MockkBean
 import io.mockk.every
-import io.mockk.mockk
-import io.mockk.slot
 import io.restassured.module.mockmvc.RestAssuredMockMvc
 import org.junit.jupiter.api.BeforeEach
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.web.context.WebApplicationContext
 
+@SpringBootTest
 open class ShopBase {
+    @Autowired
+    lateinit var context: WebApplicationContext
+
+    @MockkBean
+    lateinit var shopOwnerService: ShopOwnerService
+
     @BeforeEach
     fun setup() {
-        val shopOwnerService = mockk<ShopOwnerService>()
-        val id = slot<Long>()
-        every { shopOwnerService.findShopOwnerById(capture(id)) } answers {
+        every { shopOwnerService.findShopOwnerById(any()) } answers {
+            val capturedId = firstArg<Long>()
+
+            if (capturedId % 2 == 0L) {
+                throw IllegalArgumentException("Invalid id")
+            }
+
             ShopOwnerResponse(
-                id.captured,
-                ShopResponse(listOf(1, 2, 3), "가게", id.captured)
+                capturedId,
+                ShopResponse(listOf(1, 3, 5), "가게", capturedId)
             )
         }
-        every { shopOwnerService.findShopOwnerByShopId(capture(id)) } answers {
+        every { shopOwnerService.findShopOwnerByShopId(any()) } answers {
+            val capturedId = firstArg<Long>()
+            if (capturedId % 2 == 0L) {
+                throw IllegalArgumentException("Invalid id")
+            }
+
             ShopOwnerResponse(
-                id.captured,
-                ShopResponse(listOf(1, 2, 3), "가게", id.captured)
+                capturedId,
+                ShopResponse(listOf(1, 3, 5), "가게", capturedId)
             )
         }
-        every { shopOwnerService.addRoyalCustomers(any(), any()) } returns Unit
-        RestAssuredMockMvc.standaloneSetup(ShopOwnerController(shopOwnerService))
+        every { shopOwnerService.addRoyalCustomers(any(), any()) } answers {
+            if (secondArg<Long>() % 2 == 0L) {
+                throw IllegalArgumentException("Invalid id")
+            }
+        }
+        RestAssuredMockMvc.webAppContextSetup(this.context)
     }
 }

--- a/shop/src/test/resources/contracts/shop/addRoyalCustomers.kts
+++ b/shop/src/test/resources/contracts/shop/addRoyalCustomers.kts
@@ -2,13 +2,26 @@ package shop
 
 import org.springframework.cloud.contract.spec.ContractDsl.Companion.contract
 
-contract {
-    name = "add royal customers"
-    request {
-        method = POST
-        url = url(v(regex("\\/owners\\/shop\\/[0-9]{1,10}\\/royal-customers\\/[0-9]{1,10}")))
+
+
+arrayOf(
+    contract {
+        name = "add royal customers"
+        request {
+            method = POST
+            url = url(v(regex("\\/owners\\/shop\\/[0-9]{1,8}\\/royal-customers\\/[0-9]{1,7}[13579]")))
+        }
+        response {
+            status = OK
+        }
+    },
+    contract {
+        request {
+            method = POST
+            url = url(v(regex("\\/owners\\/shop\\/[0-9]{1,8}\\/royal-customers\\/[0-9]{1,7}[02468]")))
+        }
+        response {
+            status = BAD_REQUEST
+        }
     }
-    response {
-        status = OK
-    }
-}
+)

--- a/shop/src/test/resources/contracts/shop/findShopOwnerByShopId.kts
+++ b/shop/src/test/resources/contracts/shop/findShopOwnerByShopId.kts
@@ -2,24 +2,34 @@ package shop
 
 import org.springframework.cloud.contract.spec.ContractDsl.Companion.contract
 
-contract {
-    name = "get owner shop id"
-    request {
-        method = GET
-        url = url(v(regex("\\/owners\\/shop\\/[0-9]{1,10}")))
-    }
-    response {
-        status = OK
-        headers {
-            contentType = "application/json"
+arrayOf(
+    contract {
+        request {
+            method = GET
+            url = url(v(regex("\\/owners\\/shop\\/[0-9]{1,7}[13579]")))
         }
-        body = body(
-            "id" to value("${fromRequest().path(2)}"),
-            "shop" to mapOf(
-                "royalCustomers" to listOf(1, 2, 3),
-                "name" to "가게",
-                "id" to value("${fromRequest().path(2)}")
+        response {
+            status = OK
+            headers {
+                contentType = "application/json"
+            }
+            body = body(
+                "id" to value("${fromRequest().path(2)}"),
+                "shop" to mapOf(
+                    "royalCustomers" to listOf(1, 3, 5),
+                    "name" to "가게",
+                    "id" to value("${fromRequest().path(2)}")
+                )
             )
-        )
+        }
+    },
+    contract {
+        request {
+            method = GET
+            url = url(v(regex("\\/owners\\/shop\\/[0-9]{1,7}[02468]")))
+        }
+        response {
+            status = BAD_REQUEST
+        }
     }
-}
+)

--- a/shop/src/test/resources/contracts/shop/findShopOwnerByShopOwnerId.kts
+++ b/shop/src/test/resources/contracts/shop/findShopOwnerByShopOwnerId.kts
@@ -2,24 +2,34 @@ package shop
 
 import org.springframework.cloud.contract.spec.ContractDsl.Companion.contract
 
-contract {
-    name = "get owner id"
-    request {
-        method = GET
-        url = url(v(regex("\\/owners\\/[0-9]{1,10}")))
-    }
-    response {
-        status = OK
-        headers {
-            contentType = "application/json"
+arrayOf(
+    contract {
+        request {
+            method = GET
+            url = url(v(regex("\\/owners\\/[0-9]{1,7}[13579]")))
         }
-        body = body(
-            "id" to value("${fromRequest().path(1)}"),
-            "shop" to mapOf(
-                "royalCustomers" to listOf(1, 2, 3),
-                "name" to "가게",
-                "id" to value("${fromRequest().path(1)}")
+        response {
+            status = OK
+            headers {
+                contentType = "application/json"
+            }
+            body = body(
+                "id" to value("${fromRequest().path(1)}"),
+                "shop" to mapOf(
+                    "royalCustomers" to listOf(1, 3, 5),
+                    "name" to "가게",
+                    "id" to value("${fromRequest().path(1)}")
+                )
             )
-        )
+        }
+    },
+    contract {
+        request {
+            method = GET
+            url = url(v(regex("\\/owners\\/[0-9]{1,7}[02468]")))
+        }
+        response {
+            status = BAD_REQUEST
+        }
     }
-}
+)


### PR DESCRIPTION
### Summary

- 다방면 케이스를 고려하기 위해 계약을 명세합니다.

### Description

추가될 계약서 명세는 다음과 같습니다.

- `홀수 식별자`인 경우 존재하는 회원입니다. `200` 과 함께 정보를 반환합니다.
- `짝수 식별자`인 경우 존재하지 않는 회원입니다. `400`를 반환합니다.
- `가게 단골`은 `홀수 식별자`를 가진 회원인 `1, 3, 5` 만 존재합니다.
- 식별자 `999`를 조회한다면 무조건 `500 ERROR`가 발생합니다.
- 특수 예외가 존재한다면 1000 이상의 숫자를 지정합니다. 각 예외 사항은 모듈마다 표로 관리해야 합니다.
- 식별자의 최대 자리수는 8자리입니다.